### PR TITLE
Puppet 3 compat

### DIFF
--- a/templates/hitch.conf.erb
+++ b/templates/hitch.conf.erb
@@ -1,9 +1,9 @@
 # Configuration for hitch
 
-user     = "<%= @user %>"
-group    = "<%= @group %>"
-frontend = "<%= @frontend %>"
-backend  = "<%= @backend %>"
+user     = "<%= scope['hitch::params::user'] %>"
+group    = "<%= scope['hitch::params::group'] %>"
+frontend = "<%= scope['hitch::frontend'] %>"
+backend  = "<%= scope['hitch::backend'] %>"
 
 <% if @write_proxy_v2 == "on" -%>
 # use the PROXY v2 protocol to communicate with backend

--- a/templates/hitch.conf.erb
+++ b/templates/hitch.conf.erb
@@ -5,11 +5,11 @@ group    = "<%= scope['hitch::params::group'] %>"
 frontend = "<%= scope['hitch::frontend'] %>"
 backend  = "<%= scope['hitch::backend'] %>"
 
-<% if @write_proxy_v2 == "on" -%>
+<% if scope['hitch::write_proxy_v2'] == "on" -%>
 # use the PROXY v2 protocol to communicate with backend
-write-proxy-v2 = "<%= @write_proxy_v2 %>"
+write-proxy-v2 = "<%= scope['hitch::write_proxy_v2'] %>"
 <% end -%>
 
 # Define a cipher list for communication
-ciphers               = "<%= @ciphers %>"
+ciphers               = "<%= scope['hitch::ciphers'] %>"
 prefer-server-ciphers = on


### PR DESCRIPTION
Hello there. Puppet 3 does not automatically create variables from parent scopes.

This fixes compatibility with puppet 3.
