### PR TITLE
Feature/rl patch

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,7 @@
 fixtures:
   forge_modules:
-    stdlib: "puppetlabs/stdlib"
     concat: "puppetlabs/concat"
-  symlinks:
-    hitch: "#{source_dir}"
+    inifile: "puppetlabs/inifile"
+    stdlib: "puppetlabs/stdlib"
+    systemd: "camptocamp/systemd"
+    translate: "puppetlabs/translate"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -11,6 +11,9 @@ hitch::frontend: "[*]:443"
 hitch::backend: "[::1]:80"
 hitch::write_proxy_v2: "off"
 hitch::ciphers: "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH"
-hitch::prefer_server_ciphers: "on"
 hitch::domains: {}
 hitch::manage_repo: false
+hitch::workers: "auto"
+hitch::prefer_server_ciphers: "on"
+hitch::alpn_protos: "http/1.1"
+hitch::tls_protos: :undef

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,15 +11,15 @@ class hitch::config (
   String $file_owner,
   String $user,
   String $group,
-  Optional[String] $dhparams_content,
   Enum['on','off'] $write_proxy_v2,
   Variant[String, Array] $frontend,
   String $backend,
   String $ciphers,
   Variant[Integer, Enum['auto']] $workers,
   Enum['on','off'] $prefer_server_ciphers,
-  Optional[String] $alpn_protos,
-  Optional[String] $tls_protos,
+  Optional[String] $dhparams_content = undef,
+  Optional[String] $alpn_protos = undef,
+  Optional[String] $tls_protos = undef,
 ) {
 
   case $frontend {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,10 +13,22 @@ class hitch::config (
   String $group,
   Optional[String] $dhparams_content,
   Enum['on','off'] $write_proxy_v2,
-  String $frontend,
+  Variant[String, Array] $frontend,
   String $backend,
   String $ciphers,
+  Variant[Integer, Enum['auto']] $workers,
+  Enum['on','off'] $prefer_server_ciphers,
+  Optional[String] $alpn_protos,
+  Optional[String] $tls_protos,
 ) {
+
+  if is_array($frontend) {
+    $frontend_array = $frontend
+  } elsif is_string($frontend) {
+    $frontend_string = $frontend
+  } else {
+    notify {'invalid $frontend': }
+  }
 
   file { $config_root:
     ensure  => directory,
@@ -59,5 +71,4 @@ class hitch::config (
     content => template('hitch/hitch.conf.erb'),
     target  => $config_file,
   }
-
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,12 +22,16 @@ class hitch::config (
   Optional[String] $tls_protos,
 ) {
 
-  if is_array($frontend) {
-    $frontend_array = $frontend
-  } elsif is_string($frontend) {
-    $frontend_string = $frontend
-  } else {
-    notify {'invalid $frontend': }
+  case $frontend {
+    Array: {
+      $frontend_array = $frontend
+    }
+    String: {
+      $frontend_string = $frontend
+    }
+    default: {
+      fail('invalid frontend')
+    }
   }
 
   file { $config_root:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,8 +36,8 @@
 #   If true, will delete all unmanaged files from the config_root.
 #   Defaults to false.
 #
-# @param frontend[String]
-#   The listening frontend for hitch.
+# @param frontend[Variant[String, Array]]
+#   The listening frontend(s) for hitch.
 #
 # @param manage_repo [Boolean]
 #    If true, install the EPEL repository on RedHat OS family.
@@ -52,13 +52,17 @@ class hitch (
   Stdlib::Absolutepath $dhparams_file,
   Stdlib::Absolutepath $config_root,
   Boolean $purge_config_root,
-  String $frontend,
+  Variant[String, Array] $frontend,
   String $backend,
   Enum['on', 'off'] $write_proxy_v2,
   String $ciphers,
   Optional[Hash] $domains,
   Optional[String] $dhparams_content,
   Boolean $manage_repo,
+  Variant[Integer, Enum['auto']] $workers,
+  Enum['on','off'] $prefer_server_ciphers,
+  Optional[String] $alpn_protos,
+  Optional[String] $tls_protos,
 ) {
 
   class { '::hitch::install':
@@ -66,18 +70,22 @@ class hitch (
     manage_repo => $manage_repo,
   }
   -> class { '::hitch::config':
-    config_root       => $config_root,
-    config_file       => $config_file,
-    dhparams_file     => $dhparams_file,
-    dhparams_content  => $dhparams_content,
-    purge_config_root => $purge_config_root,
-    file_owner        => $file_owner,
-    user              => $user,
-    group             => $group,
-    frontend          => $frontend,
-    backend           => $backend,
-    write_proxy_v2    => $write_proxy_v2,
-    ciphers           => $ciphers,
+    config_root           => $config_root,
+    config_file           => $config_file,
+    dhparams_file         => $dhparams_file,
+    dhparams_content      => $dhparams_content,
+    purge_config_root     => $purge_config_root,
+    file_owner            => $file_owner,
+    user                  => $user,
+    group                 => $group,
+    frontend              => $frontend,
+    backend               => $backend,
+    write_proxy_v2        => $write_proxy_v2,
+    ciphers               => $ciphers,
+    workers               => $workers,
+    prefer_server_ciphers => $prefer_server_ciphers,
+    alpn_protos           => $alpn_protos,
+    tls_protos            => $tls_protos,
   }
   ~> class { '::hitch::service':
     service_name => $service_name,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,4 +13,10 @@ class hitch::service (
     hasstatus  => true,
     hasrestart => true,
   }
+
+  # configure hitch.service
+  systemd::dropin_file { 'limits.conf':
+    unit    => 'hitch.service',
+    content => template('hitch/limits.conf.erb'),
+  }
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -18,17 +18,35 @@ describe 'hitch::config' do
           frontend: '[*]:443',
           backend: '[::1]:80',
           ciphers: 'MODERN',
+          workers: 'auto',
+          prefer_server_ciphers: 'on',
         }
       end
 
-      it { is_expected.to compile }
-      it { is_expected.to contain_file('/etc/hitch') }
+      context 'defaults' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_file('/etc/hitch') }
 
-      it { is_expected.to contain_concat('/etc/hitch/hitch.conf') }
-      it { is_expected.to contain_concat__fragment('hitch::config config') }
+        it { is_expected.to contain_concat('/etc/hitch/hitch.conf') }
+        it { is_expected.to contain_concat__fragment('hitch::config config') }
 
-      it { is_expected.to contain_file('/etc/hitch/dhparams.pem') }
-      it { is_expected.to contain_exec('hitch::config generate dhparams') }
+        it { is_expected.to contain_file('/etc/hitch/dhparams.pem') }
+        it { is_expected.to contain_exec('hitch::config generate dhparams') }
+      end
+
+      context 'with frontend as array of strings' do
+        let(:params) do
+          super().merge(frontend: ['[192.0.2.1]:443', '[192.0.2.2]:443'])
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_concat('/etc/hitch/hitch.conf') }
+        it {
+          is_expected.to contain_concat__fragment('hitch::config config')
+            .with_content(%r{^frontend = "\[192\.0\.2\.1\]:443"$})
+            .with_content(%r{^frontend = "\[192\.0\.2\.2\]:443"$})
+        }
+      end
     end
   end
 end

--- a/templates/hitch.conf.erb
+++ b/templates/hitch.conf.erb
@@ -2,14 +2,34 @@
 
 user     = "<%= @user %>"
 group    = "<%= @group %>"
-frontend = "<%= @frontend %>"
+<% if @frontend_string -%>
+frontend = "<%= @frontend_string %>"
+<% end -%>
+<% if @frontend_array -%>
+<% @frontend_array.each do |frontend| -%>
+frontend = "<%= frontend %>"
+<% end -%>
+<% end -%>
 backend  = "<%= @backend %>"
-
+<% if @workers == 'auto' && @facts['processors']['count'] -%>
+workers  = <%= @facts['processors']['count'] %>
+<% elsif @workers.respond_to?(:to_i) -%>
+workers  = <%= @workers %>
+<% end -%>
 <% if @write_proxy_v2 == "on" -%>
 # use the PROXY v2 protocol to communicate with backend
 write-proxy-v2 = "<%= @write_proxy_v2 %>"
 <% end -%>
-
+<% if @alpn_protos -%>
+alpn-protos = "<%= @alpn_protos %>"
+<% end -%>
+<% if @tls_protos %>
+tls-protos = <%= @tls_protos %>
+<% end -%>
+<% if @ciphers.length > 0 -%>
 # Define a cipher list for communication
 ciphers               = "<%= @ciphers %>"
-prefer-server-ciphers = on
+<% end -%>
+<% if @prefer_server_ciphers -%>
+prefer-server-ciphers = <%= @prefer_server_ciphers %>
+<% end -%>

--- a/templates/limits.conf.erb
+++ b/templates/limits.conf.erb
@@ -1,0 +1,2 @@
+[Service]
+LimitNOFILE=65536


### PR DESCRIPTION
Received patch for supporting

* change parameter `$frontend` to set multiple frontends as an array of strings in addition to a single frontend as string.
* parameter `$workers` added with default value `"auto"`
* parameter `$prefer_server_ciphers` added with default value `"on"`
* parameter `$alpn_protos` added with default value `"http/1.1"`
* parameter `$tls_protos` added with default value `undef`

In addition
* Replace deprecated functions from patch with data type checks.
* Fixed and updated unit tests